### PR TITLE
Fix CORS by using explicit origin instead of wildcard with credentials

### DIFF
--- a/paranoia-backend/app/main.py
+++ b/paranoia-backend/app/main.py
@@ -35,8 +35,7 @@ app = FastAPI(lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
+    allow_origins=[FRONTEND_BASE_URL],
     allow_methods=["*"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
Combining allow_origins=["*"] with allow_credentials=True violates the CORS spec — browsers reject wildcard origins when credentials are in play. Switched to allow_origins=[FRONTEND_BASE_URL] and removed allow_credentials since the app uses no cookies or auth headers.